### PR TITLE
[119220] Preparations for CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,4 @@ to request features or report bugs.
 
 ## Testing
     
-    $ cd tests
     $ PM_API_KEY=your-api-key rake test

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,19 @@
 require 'rubygems'
 require 'rake/testtask'
-require 'rcov/rcovtask'
 
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
+  test.test_files = FileList['test/test_*.rb'].exclude('test/test_helper.rb')
   test.verbose = true
 end
 
-Rcov::RcovTask.new do |t|
-  t.test_files = FileList['test/test_*.rb']
-  #t.verbose = true     # uncomment to see the executed command
+if ENV['coverage'] and RUBY_VERSION < "1.9"
+  require 'rcov/rcovtask'
+  Rcov::RcovTask.new do |t|
+    t.test_files = FileList['test/test_*.rb'].exclude('test/test_helper.rb')
+    #t.verbose = true     # uncomment to see the executed command
+  end
 end
 
 
 task :default => [:test]
-

--- a/Rakefile
+++ b/Rakefile
@@ -18,13 +18,18 @@ if ENV['CI_SERVER']
   ENV['coverage'] = '1'
 end
 
-if ENV['coverage'] and RUBY_VERSION < "1.9"
+if RUBY_VERSION < "1.9"
   require 'rcov/rcovtask'
-  Rcov::RcovTask.new do |t|
-    t.test_files = FileList['test/test_*.rb'].exclude('test/test_helper.rb')
-    #t.verbose = true     # uncomment to see the executed command
+  Rcov::RcovTask.new do |test|
+    test.libs << 'lib' << 'test'
+    test.test_files = FileList['test/test_*.rb'].exclude('test/test_helper.rb')
+    test.rcov_opts = %w{--exclude gems\/}
+    #test.verbose = true     # uncomment to see the executed command
   end
 end
 
-
-task :default => [:test]
+if ENV['coverage'] and RUBY_VERSION < "1.9"
+  task :default => [:rcov]
+else
+  task :default => [:test]
+end

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,17 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
+if ENV['CI_SERVER']
+  if RUBY_VERSION < "1.9"
+    require 'ci/reporter/rake/test_unit'
+    task :test => 'ci:setup:testunit'
+  else
+    require 'ci/reporter/rake/minitest'
+    task :test => 'ci:setup:minitest'
+  end
+  ENV['coverage'] = '1'
+end
+
 if ENV['coverage'] and RUBY_VERSION < "1.9"
   require 'rcov/rcovtask'
   Rcov::RcovTask.new do |t|

--- a/test/test_address.rb
+++ b/test/test_address.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+require 'test_helper'
 require 'test/unit'
 require 'postmaster'
 require 'rubygems'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,9 @@ if ENV['coverage'] and RUBY_VERSION >= "1.9"
   require 'simplecov'
   require 'simplecov-rcov'
   SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start
+  SimpleCov.start do
+    add_filter 'test_'
+  end
 end
 
 require 'stringio'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,10 @@
+if ENV['coverage'] and RUBY_VERSION >= "1.9"
+  require 'simplecov'
+  require 'simplecov-rcov'
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start
+end
+
 require 'stringio'
 require 'test/unit'
 require 'postmaster'

--- a/test/test_postmaster.rb
+++ b/test/test_postmaster.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+require 'test_helper'
 require 'test/unit'
 require 'postmaster'
 require 'shoulda'

--- a/test/test_rates.rb
+++ b/test/test_rates.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+require 'test_helper'
 require 'test/unit'
 require 'postmaster'
 require 'rubygems'

--- a/test/test_shipment.rb
+++ b/test/test_shipment.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+require 'test_helper'
 require 'test/unit'
 require 'postmaster'
 require 'rubygems'

--- a/test/test_tracking.rb
+++ b/test/test_tracking.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+require 'test_helper'
 require 'test/unit'
 require 'postmaster'
 require 'rubygems'

--- a/test/test_transit_times.rb
+++ b/test/test_transit_times.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+require 'test_helper'
 require 'test/unit'
 require 'postmaster'
 require 'rubygems'


### PR DESCRIPTION
There are several things here, all related to CI support:
1. Fixed test_helper requires, so it gets called before any other code (it is important).
2. For ruby > 1.8, use SimpleCov coverage library, instead of RCov. RCov is not maintained and does not work for newer Ruby versions. SimpleCov does not work for older...
3. Coverage is only calculated if either `CI_SERVER` or `coverage` environment flag is set.
4. Use ci_reporter to generate XML reports that CI server can understand. It is only run if `CI_SERVER` environment flag is set.

Also note that there are some workarounds required for ruby < 1.9. As those versions are [no longed supported](https://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/), I think we might consider dropping support, too.
